### PR TITLE
chore(prisma): configure neon adapter and indexes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Neon PostgreSQL connection URLs
+DATABASE_URL="postgresql://USER:PASS@HOST-pooler.neon.tech:5432/DB?sslmode=require"
+DIRECT_URL="postgresql://USER:PASS@HOST.neon.tech:5432/DB?sslmode=require"
+SHADOW_DATABASE_URL="postgresql://USER:PASS@HOST.neon.tech:5432/DB_shadow?sslmode=require"

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,10 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files
-.env*
+.env
+.env.local
+.env.*.local
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ FleetFusion is a Next.js 15 application for managing construction projects, time
    npm install
    ```
 2. **Set environment variables**
-   - Create a `.env` file based on `.env.example` and set `DATABASE_URL`.
+   - Create a `.env` file based on `.env.example` and set `DATABASE_URL`, `DIRECT_URL`, and `SHADOW_DATABASE_URL`.
 3. **Run database migrations**
    ```bash
    npx prisma migrate dev

--- a/app/api/timesheets/[id]/approve/route.ts
+++ b/app/api/timesheets/[id]/approve/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       where: { id: params.id },
       data: {
         approved: true,
-        approvedBy: dbUser.id,
+        approvedById: dbUser.id,
       },
       include: {
         project: { select: { name: true } },

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,8 +4,8 @@ This document explains how to set up the project, run it locally, and contribute
 
 ## Environment Setup
 - Node.js 18 or later
-- PostgreSQL database
-- Copy `.env.example` to `.env` and configure required variables such as `DATABASE_URL`.
+- PostgreSQL database (Neon recommended)
+- Copy `.env.example` to `.env` and configure `DATABASE_URL`, `DIRECT_URL`, and `SHADOW_DATABASE_URL`.
 
 Install dependencies:
 ```bash

--- a/lib/prisma-edge.ts
+++ b/lib/prisma-edge.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client'
+import { neon } from '@neondatabase/serverless'
+import { PrismaNeonHTTP } from '@prisma/adapter-neon'
+
+const sql = neon(process.env.DIRECT_URL!)
+const adapter = new PrismaNeonHTTP(sql)
+
+export const prismaEdge = new PrismaClient({ adapter })

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from '@prisma/client'
+import { Pool } from '@neondatabase/serverless'
+import { PrismaNeon } from '@prisma/adapter-neon'
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL! })
+const adapter = new PrismaNeon(pool)
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined
+}
+
+export const prisma =
+  global.prisma ??
+  new PrismaClient({
+    adapter,
+    log:
+      process.env.NODE_ENV === 'development'
+        ? ['query', 'error', 'warn']
+        : ['error'],
+  })
+
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,12 @@
     "": {
       "name": "my-v0-project",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@clerk/nextjs": "latest",
         "@hookform/resolvers": "^3.10.0",
+        "@neondatabase/serverless": "latest",
+        "@prisma/adapter-neon": "latest",
         "@prisma/client": "latest",
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-alert-dialog": "1.1.4",
@@ -681,6 +684,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.1.tgz",
+      "integrity": "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.15.30",
+        "@types/pg": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=19.0.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.2.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.4.tgz",
@@ -815,6 +831,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@prisma/adapter-neon": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-neon/-/adapter-neon-6.14.0.tgz",
+      "integrity": "sha512-rvBDr3FzLOiCS8dNsfKQDPvUXlK+BtMGE+ZY43c8qkyvbQLp6ZO2fF9O4LCGAfo2OEZSSvf1gCzs4Y2ASkFJYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@neondatabase/serverless": ">0.6.0 <2",
+        "@prisma/driver-adapter-utils": "6.14.0",
+        "postgres-array": "3.0.4"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.14.0.tgz",
@@ -854,6 +881,15 @@
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.14.0.tgz",
       "integrity": "sha512-j4Lf+y+5QIJgQD4sJWSbkOD7geKx9CakaLp/TyTy/UDu9Wo0awvWCBH/BAxTHUaCpIl9USA5VS/KJhDqKJSwug==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-6.14.0.tgz",
+      "integrity": "sha512-On9vTNiJ7J/O1kVqedLtfdhhrfRYprkUOhxjlmmWEv12WNdG6v5x4PsrfZXdBtZqRZaqK1i1TigO6IdtYh8z+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.14.0"
+      }
     },
     "node_modules/@prisma/engines": {
       "version": "6.14.0",
@@ -3826,10 +3862,20 @@
       "version": "22.17.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
       "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+      "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -5089,6 +5135,46 @@
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5140,6 +5226,45 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prisma": {
       "version": "6.14.0",
@@ -5682,7 +5807,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -5800,6 +5924,15 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@clerk/nextjs": "latest",
     "@hookform/resolvers": "^3.10.0",
     "@prisma/client": "latest",
+    "@prisma/adapter-neon": "latest",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
     "@radix-ui/react-aspect-ratio": "1.1.1",
@@ -52,6 +54,7 @@
     "next": "15.2.4",
     "next-themes": "^0.4.6",
     "prisma": "latest",
+    "@neondatabase/serverless": "latest",
     "react": "^19",
     "react-day-picker": "9.8.0",
     "react-dom": "^19",

--- a/prisma/migrations/20250820000000_add_indexes_and_relations/migration.sql
+++ b/prisma/migrations/20250820000000_add_indexes_and_relations/migration.sql
@@ -1,0 +1,27 @@
+-- Rename column and add foreign key
+ALTER TABLE "time_entries" RENAME COLUMN "approvedBy" TO "approvedById";
+ALTER TABLE "time_entries" ADD CONSTRAINT "time_entries_approvedById_fkey" FOREIGN KEY ("approvedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Indexes for relations
+CREATE INDEX "projects_clientId_idx" ON "projects" ("clientId");
+CREATE INDEX "projects_createdById_idx" ON "projects" ("createdById");
+
+CREATE INDEX "daily_logs_projectId_idx" ON "daily_logs" ("projectId");
+CREATE INDEX "daily_logs_createdById_idx" ON "daily_logs" ("createdById");
+
+CREATE INDEX "log_photos_logId_idx" ON "log_photos" ("logId");
+
+CREATE INDEX "time_entries_projectId_idx" ON "time_entries" ("projectId");
+CREATE INDEX "time_entries_userId_idx" ON "time_entries" ("userId");
+CREATE INDEX "time_entries_approvedById_idx" ON "time_entries" ("approvedById");
+
+CREATE INDEX "tasks_projectId_idx" ON "tasks" ("projectId");
+CREATE INDEX "tasks_assigneeId_idx" ON "tasks" ("assigneeId");
+
+CREATE INDEX "documents_projectId_idx" ON "documents" ("projectId");
+CREATE INDEX "documents_uploadedById_idx" ON "documents" ("uploadedById");
+
+CREATE INDEX "purchase_orders_projectId_idx" ON "purchase_orders" ("projectId");
+CREATE INDEX "purchase_orders_vendorId_idx" ON "purchase_orders" ("vendorId");
+
+CREATE INDEX "po_items_poId_idx" ON "po_items" ("poId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,8 +6,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model User {
@@ -21,17 +22,18 @@ model User {
   updatedAt DateTime @updatedAt
 
   // Relations
-  timeEntries    TimeEntry[]
-  createdProjects Project[] @relation("ProjectCreator")
-  assignedTasks  Task[]
-  uploadedDocs   Document[]
-  dailyLogs      DailyLog[]
+  timeEntries         TimeEntry[]
+  approvedTimeEntries TimeEntry[] @relation("TimeEntryApprovedBy")
+  createdProjects     Project[]   @relation("ProjectCreator")
+  assignedTasks       Task[]
+  uploadedDocs        Document[]
+  dailyLogs           DailyLog[]
 
   @@map("users")
 }
 
 model Project {
-  id          String      @id @default(cuid())
+  id          String        @id @default(cuid())
   name        String
   description String?
   location    String?
@@ -40,18 +42,20 @@ model Project {
   status      ProjectStatus @default(ACTIVE)
   clientId    String?
   createdById String
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
 
   // Relations
-  createdBy     User           @relation("ProjectCreator", fields: [createdById], references: [id])
-  client        Entity?        @relation(fields: [clientId], references: [id])
-  dailyLogs     DailyLog[]
-  timeEntries   TimeEntry[]
-  tasks         Task[]
-  documents     Document[]
+  createdBy      User            @relation("ProjectCreator", fields: [createdById], references: [id])
+  client         Entity?         @relation(fields: [clientId], references: [id])
+  dailyLogs      DailyLog[]
+  timeEntries    TimeEntry[]
+  tasks          Task[]
+  documents      Document[]
   purchaseOrders PurchaseOrder[]
 
+  @@index([clientId])
+  @@index([createdById])
   @@map("projects")
 }
 
@@ -72,6 +76,8 @@ model DailyLog {
   createdBy User       @relation(fields: [createdById], references: [id])
   photos    LogPhoto[]
 
+  @@index([projectId])
+  @@index([createdById])
   @@map("daily_logs")
 }
 
@@ -85,26 +91,31 @@ model LogPhoto {
   // Relations
   log DailyLog @relation(fields: [logId], references: [id], onDelete: Cascade)
 
+  @@index([logId])
   @@map("log_photos")
 }
 
 model TimeEntry {
-  id          String    @id @default(cuid())
-  projectId   String
-  userId      String
-  date        DateTime
-  hoursWorked Float
-  overtime    Float     @default(0)
-  description String?
-  approved    Boolean   @default(false)
-  approvedBy  String?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  id           String   @id @default(cuid())
+  projectId    String
+  userId       String
+  date         DateTime
+  hoursWorked  Float
+  overtime     Float    @default(0)
+  description  String?
+  approved     Boolean  @default(false)
+  approvedById String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
   // Relations
-  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  user    User    @relation(fields: [userId], references: [id])
+  project    Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  user       User    @relation(fields: [userId], references: [id])
+  approvedBy User?   @relation("TimeEntryApprovedBy", fields: [approvedById], references: [id])
 
+  @@index([projectId])
+  @@index([userId])
+  @@index([approvedById])
   @@map("time_entries")
 }
 
@@ -124,52 +135,58 @@ model Task {
   project  Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
   assignee User?   @relation(fields: [assigneeId], references: [id])
 
+  @@index([projectId])
+  @@index([assigneeId])
   @@map("tasks")
 }
 
 model Document {
-  id          String       @id @default(cuid())
-  projectId   String?
-  title       String
-  type        DocumentType
-  url         String
-  fileSize    Int?
-  mimeType    String?
+  id           String       @id @default(cuid())
+  projectId    String?
+  title        String
+  type         DocumentType
+  url          String
+  fileSize     Int?
+  mimeType     String?
   uploadedById String
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
 
   // Relations
   project    Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
   uploadedBy User     @relation(fields: [uploadedById], references: [id])
 
+  @@index([projectId])
+  @@index([uploadedById])
   @@map("documents")
 }
 
 model PurchaseOrder {
-  id          String    @id @default(cuid())
-  projectId   String
-  vendorId    String
-  poNumber    String    @unique
-  description String?
-  totalAmount Float
-  status      POStatus  @default(PENDING)
-  orderDate   DateTime  @default(now())
+  id           String    @id @default(cuid())
+  projectId    String
+  vendorId     String
+  poNumber     String    @unique
+  description  String?
+  totalAmount  Float
+  status       POStatus  @default(PENDING)
+  orderDate    DateTime  @default(now())
   expectedDate DateTime?
   receivedDate DateTime?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
   // Relations
-  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  vendor  Entity  @relation(fields: [vendorId], references: [id])
+  project Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  vendor  Entity   @relation(fields: [vendorId], references: [id])
   items   POItem[]
 
+  @@index([projectId])
+  @@index([vendorId])
   @@map("purchase_orders")
 }
 
 model POItem {
-  id          String  @id @default(cuid())
+  id          String @id @default(cuid())
   poId        String
   description String
   quantity    Float
@@ -179,6 +196,7 @@ model POItem {
   // Relations
   purchaseOrder PurchaseOrder @relation(fields: [poId], references: [id], onDelete: Cascade)
 
+  @@index([poId])
   @@map("po_items")
 }
 
@@ -191,7 +209,7 @@ model Entity {
   email       String?
   address     String?
   notes       String?
-  schedule    String?    // For burrito trucks and other scheduled services
+  schedule    String? // For burrito trucks and other scheduled services
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 

--- a/scripts/db-health.ts
+++ b/scripts/db-health.ts
@@ -1,0 +1,12 @@
+import { prisma } from '../lib/prisma'
+
+async function main() {
+  console.log('ping:', await prisma.$queryRaw`select 1 as ok`)
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })


### PR DESCRIPTION
## Summary
- use Neon pool adapter for Prisma with serverless and add optional edge client
- document pooled, direct, and shadow URLs and set up environment example
- expand Prisma schema with indexes and `approvedById` relation

## Testing
- `npx prisma format`
- `DIRECT_URL=postgresql://user:pass@localhost:5432/db npx prisma validate`
- `DIRECT_URL=postgresql://user:pass@localhost:5432/db npx prisma generate`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db DIRECT_URL=postgresql://user:pass@localhost:5432/db npx prisma migrate status` *(fails: Can't reach database server at `localhost:5432`)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b7e411b8832788500054d651ceb5