### PR TITLE
fix: validate database url for prisma

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -2,7 +2,15 @@ import { PrismaClient } from '@prisma/client'
 import { Pool } from '@neondatabase/serverless'
 import { PrismaNeon } from '@prisma/adapter-neon'
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL! })
+const getDatabaseUrl = (): string => {
+  const url = process.env.DATABASE_URL
+  if (typeof url !== 'string' || url.length === 0) {
+    throw new Error('DATABASE_URL environment variable must be a non-empty string')
+  }
+  return url
+}
+
+const pool = new Pool({ connectionString: getDatabaseUrl() })
 const adapter = new PrismaNeon(pool)
 
 declare global {


### PR DESCRIPTION
## Summary
- ensure DATABASE_URL env var is a non-empty string before initializing Prisma

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee8c3bec832791567978faee7a90