### PR TITLE
feat: add task creation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## ✨ Features
 
 - **Project Management** — Overview pages, client info, project status. 
-- **Task Tracking** — Track to‑dos & inspections across jobs. 
+- **Task Tracking** — Track to‑dos & inspections across jobs. Create tasks from the dashboard and assign due dates per project.
 - **Time Tracking** — Capture worker hours and summarize for payroll. 
 - **Daily Logs** — Record onsite activity with photos.  
 - **Document Handling** — Upload & organize project files. 

--- a/app/dashboard/projects/[id]/page.tsx
+++ b/app/dashboard/projects/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ArrowLeft, Edit, MapPin, Calendar, Users, CheckSquare, FileText, Clock, Plus } from "lucide-react"
 import { format } from "date-fns"
+import { TaskCard } from "@/components/tasks/task-card"
 
 export default async function ProjectDetailPage({
   params,
@@ -237,15 +238,7 @@ export default async function ProjectDetailPage({
               ) : (
                 <div className="space-y-4">
                   {project.tasks.map((task) => (
-                    <div key={task.id} className="flex items-center justify-between p-4 border rounded-lg">
-                      <div>
-                        <h4 className="font-medium">{task.title}</h4>
-                        <p className="text-sm text-muted-foreground">
-                          {task.assignee && `Assigned to ${task.assignee.firstName} ${task.assignee.lastName}`}
-                        </p>
-                      </div>
-                      <Badge variant="outline">{task.status.replace("_", " ")}</Badge>
-                    </div>
+                    <TaskCard key={task.id} task={task} />
                   ))}
                 </div>
               )}

--- a/app/dashboard/tasks/new/page.tsx
+++ b/app/dashboard/tasks/new/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { TaskCreate } from '@/features/tasks/task-create'
+
+interface PageProps {
+  searchParams: Promise<{ project?: string }>
+}
+
+export default async function Page({ searchParams }: PageProps) {
+  const { project } = await searchParams
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-foreground">Add Task</h1>
+      <Suspense fallback={<div>Loading...</div>}>
+        <TaskCreate projectId={project} />
+      </Suspense>
+    </div>
+  )
+}

--- a/components/tasks/task-card.tsx
+++ b/components/tasks/task-card.tsx
@@ -1,0 +1,22 @@
+interface TaskCardProps {
+  task: {
+    id: string
+    title: string
+    status: string
+    dueDate?: Date | null
+  }
+}
+
+export function TaskCard({ task }: TaskCardProps) {
+  return (
+    <div className="rounded-md shadow-md bg-black p-6 border border-gray-200">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-foreground">{task.title}</h3>
+        <span className="text-sm text-muted-foreground">{task.status.replace('_', ' ')}</span>
+      </div>
+      {task.dueDate && (
+        <p className="mt-2 text-sm text-muted-foreground">Due {task.dueDate.toLocaleDateString()}</p>
+      )}
+    </div>
+  )
+}

--- a/components/tasks/task-form.tsx
+++ b/components/tasks/task-form.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useActionState } from 'react'
+import { useFormStatus } from 'react-dom'
+import { createTask } from '@/lib/actions/tasks'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+interface TaskFormProps {
+  projectId?: string
+  projects: { id: string; name: string }[]
+}
+
+export function TaskForm({ projectId, projects }: TaskFormProps) {
+  const [state, action] = useActionState(createTask, undefined)
+  return (
+    <form action={action} className="space-y-4">
+      <select
+        name="projectId"
+        defaultValue={projectId}
+        className="w-full rounded-md border border-gray-200 bg-black p-2 text-foreground"
+      >
+        <option value="" disabled>
+          Select project
+        </option>
+        {projects.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+      <Input name="title" placeholder="Task title" required />
+      <Input type="date" name="dueDate" />
+      <SubmitButton />
+      {state?.error && <p className="text-sm text-destructive">{state.error}</p>}
+    </form>
+  )
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? 'Saving...' : 'Add Task'}
+    </Button>
+  )
+}

--- a/features/tasks/task-create.tsx
+++ b/features/tasks/task-create.tsx
@@ -1,0 +1,20 @@
+import { prisma } from '@/lib/db'
+import { TaskForm } from '@/components/tasks/task-form'
+
+interface TaskCreateProps {
+  projectId?: string
+}
+
+export async function TaskCreate({ projectId }: TaskCreateProps) {
+  const projects = await prisma.project.findMany({
+    select: { id: true, name: true },
+    orderBy: { name: 'asc' },
+  })
+
+  return (
+    <div className="rounded-md shadow-md bg-black p-6 border border-gray-200">
+      <h2 className="text-lg font-semibold mb-4 text-foreground">New Task</h2>
+      <TaskForm projectId={projectId} projects={projects} />
+    </div>
+  )
+}

--- a/features/tasks/task-list.tsx
+++ b/features/tasks/task-list.tsx
@@ -1,0 +1,21 @@
+import { prisma } from '@/lib/db'
+import { TaskCard } from '@/components/tasks/task-card'
+
+interface TaskListProps {
+  projectId: string
+}
+
+export async function TaskList({ projectId }: TaskListProps) {
+  const tasks = await prisma.task.findMany({
+    where: { projectId },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return (
+    <div className="space-y-4">
+      {tasks.map((task) => (
+        <TaskCard key={task.id} task={task} />
+      ))}
+    </div>
+  )
+}

--- a/lib/actions/tasks.test.ts
+++ b/lib/actions/tasks.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { taskSchema } from './tasks'
+
+describe('taskSchema', () => {
+  it('rejects missing title', () => {
+    const result = taskSchema.safeParse({ projectId: 'ck123' })
+    expect(result.success).toBe(false)
+  })
+  it('accepts valid data', () => {
+    const result = taskSchema.safeParse({ projectId: 'c123456789012345678901234', title: 'Test' })
+    expect(result.success).toBe(true)
+  })
+})

--- a/lib/actions/tasks.ts
+++ b/lib/actions/tasks.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import { z } from 'zod'
+import { prisma } from '../db'
+import { revalidatePath } from 'next/cache'
+
+export const taskSchema = z.object({
+  projectId: z.string().cuid(),
+  title: z.string().min(1),
+  dueDate: z.string().optional(),
+})
+
+export async function createTask(_: unknown, formData: FormData) {
+  const raw = Object.fromEntries(formData)
+  const parsed = taskSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { error: 'Invalid input' }
+  }
+  const { projectId, title, dueDate } = parsed.data
+  await prisma.task.create({
+    data: {
+      projectId,
+      title,
+      dueDate: dueDate ? new Date(dueDate) : undefined,
+    },
+  })
+  revalidatePath(`/dashboard/projects/${projectId}`)
+  return { success: true }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -17,7 +17,6 @@ if (!adapter) {
   throw new Error('PrismaNeon adapter is null')
 }
 declare global {
-  // eslint-disable-next-line no-var
   var prisma: PrismaClient | undefined
 }
 


### PR DESCRIPTION
## Summary
- add server-side task creation action and form
- display tasks with reusable task cards
- document task workflow in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a50a057bb0832789472eb063d74ec6