### PR TITLE
feat: add daily log creation with photo upload

### DIFF
--- a/components/logs/log-form.tsx
+++ b/components/logs/log-form.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useActionState } from 'react'
+import { useFormStatus } from 'react-dom'
+import { createDailyLog } from '@/lib/actions/logs'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+
+interface LogFormProps {
+  projects: { id: string; name: string }[]
+}
+
+export function LogForm({ projects }: LogFormProps) {
+  const [state, action] = useActionState(createDailyLog, undefined)
+  return (
+    <form action={action} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="projectId">Project</Label>
+        <select
+          id="projectId"
+          name="projectId"
+          className="w-full rounded-md border border-gray-200 bg-black p-2 text-foreground"
+          defaultValue=""
+          required
+        >
+          <option value="" disabled>
+            Select project
+          </option>
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="date">Date</Label>
+          <Input id="date" type="date" name="date" required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="weather">Weather</Label>
+          <Input id="weather" name="weather" placeholder="e.g. Sunny" />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="crewCount">Crew Count</Label>
+          <Input id="crewCount" name="crewCount" type="number" min="0" />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="workDone">Work Performed</Label>
+        <Textarea id="workDone" name="workDone" required rows={4} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="notes">Notes</Label>
+        <Textarea id="notes" name="notes" rows={3} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="photos">Photos</Label>
+        <Input id="photos" name="photos" type="file" accept="image/*" multiple />
+      </div>
+      <SubmitButton />
+      {state?.error && <p className="text-sm text-destructive">{state.error}</p>}
+    </form>
+  )
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? 'Saving...' : 'Save Log'}
+    </Button>
+  )
+}

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,0 +1,12 @@
+# Daily Logs
+
+Daily logs capture on-site activity including work performed and photos.
+
+## Create a Log
+
+1. Navigate to `Dashboard > Logs > New`.
+2. Fill in project, date, weather, crew count, and work performed.
+3. Attach photos if available.
+4. Submit the form to save the log.
+
+Uploaded photos are stored under `public/uploads` and linked to the log entry.

--- a/features/logs/log-new.tsx
+++ b/features/logs/log-new.tsx
@@ -1,3 +1,10 @@
+import { prisma } from '@/lib/db'
+import { LogForm } from '@/components/logs/log-form'
+
 export async function LogNew() {
-  return <div>Log creation coming soon</div>
+  const projects = await prisma.project.findMany({
+    select: { id: true, name: true },
+    orderBy: { name: 'asc' },
+  })
+  return <LogForm projects={projects} />
 }

--- a/lib/actions/logs.test.ts
+++ b/lib/actions/logs.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { logSchema } from './logs'
+
+describe('logSchema', () => {
+  it('requires projectId and workDone and date', () => {
+    const result = logSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+  it('accepts valid data', () => {
+    const result = logSchema.safeParse({
+      projectId: 'c123456789012345678901234',
+      date: '2024-01-01',
+      workDone: 'Test log',
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/lib/actions/logs.ts
+++ b/lib/actions/logs.ts
@@ -1,0 +1,68 @@
+'use server'
+
+import { auth } from '@clerk/nextjs/server'
+import { revalidatePath } from 'next/cache'
+import { join } from 'path'
+import { mkdir, writeFile } from 'fs/promises'
+import { z } from 'zod'
+import { prisma } from '../db'
+
+export const logSchema = z.object({
+  projectId: z.string().cuid(),
+  date: z.string().min(1),
+  weather: z.string().optional(),
+  crewCount: z.coerce.number().int().optional(),
+  workDone: z.string().min(1),
+  notes: z.string().optional(),
+})
+
+export async function createDailyLog(_: unknown, formData: FormData) {
+  const { userId } = auth()
+  if (!userId) {
+    return { error: 'Unauthorized' }
+  }
+
+  const raw = Object.fromEntries(formData)
+  const parsed = logSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { error: 'Invalid input' }
+  }
+
+  const { projectId, date, weather, crewCount, workDone, notes } = parsed.data
+
+  const log = await prisma.dailyLog.create({
+    data: {
+      projectId,
+      date: new Date(date),
+      weather,
+      crewCount,
+      workDone,
+      notes,
+      createdById: userId,
+    },
+  })
+
+  const files = formData.getAll('photos') as File[]
+  if (files.length) {
+    const uploadDir = join(process.cwd(), 'public', 'uploads')
+    await mkdir(uploadDir, { recursive: true })
+
+    for (const file of files) {
+      if (!file || !file.name) continue
+      const bytes = await file.arrayBuffer()
+      const buffer = Buffer.from(bytes)
+      const filename = `${log.id}-${Date.now()}-${file.name}`
+      await writeFile(join(uploadDir, filename), buffer)
+      await prisma.logPhoto.create({
+        data: {
+          logId: log.id,
+          url: `/uploads/${filename}`,
+        },
+      })
+    }
+  }
+
+  revalidatePath('/dashboard/logs')
+  return { success: true, id: log.id }
+}
+


### PR DESCRIPTION
## Summary
- add server action for daily log creation with photo storage
- build daily log form and feature module
- document daily log workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a679ba6a84832785e202d064c95b49