### PR TITLE
fix(tasks): match dashboard design and revalidate list

### DIFF
--- a/app/dashboard/tasks/new/page.tsx
+++ b/app/dashboard/tasks/new/page.tsx
@@ -1,11 +1,11 @@
 import { Suspense } from 'react'
-import { TaskNew } from '@/features/tasks/task-new'
+import { TaskCreate } from '@/features/tasks/task-create'
 
 export default function Page() {
   return (
     <div className="space-y-6">
       <Suspense fallback={<div>Loading...</div>}>
-        <TaskNew />
+        <TaskCreate />
       </Suspense>
     </div>
   )

--- a/app/dashboard/tasks/page.tsx
+++ b/app/dashboard/tasks/page.tsx
@@ -2,6 +2,10 @@ import { Suspense } from 'react'
 import Link from 'next/link'
 import { TaskList } from '@/features/tasks/task-list'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Plus, Search } from 'lucide-react'
 
 export default function TasksPage() {
   return (
@@ -12,9 +16,34 @@ export default function TasksPage() {
           <p className="text-muted-foreground">Browse all tasks</p>
         </div>
         <Button asChild>
-          <Link href="/dashboard/tasks/new">Add Task</Link>
+          <Link href="/dashboard/tasks/new">
+            <Plus className="h-4 w-4 mr-2" />
+            Add Task
+          </Link>
         </Button>
       </div>
+
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input placeholder="Search tasks..." className="pl-10" />
+            </div>
+            <Select defaultValue="all">
+              <SelectTrigger className="w-full sm:w-48">
+                <SelectValue placeholder="Filter by status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Tasks</SelectItem>
+                <SelectItem value="TODO">To Do</SelectItem>
+                <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
+                <SelectItem value="DONE">Done</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
       <Suspense fallback={<div>Loading tasks...</div>}>
         <TaskList />
       </Suspense>

--- a/features/tasks/task-list.tsx
+++ b/features/tasks/task-list.tsx
@@ -1,5 +1,9 @@
+import Link from 'next/link'
 import { TaskCard } from '@/components/tasks/task-card'
 import { getTasks } from '@/lib/fetchers/tasks'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Plus, ClipboardList } from 'lucide-react'
 
 interface TaskListProps {
   projectId?: string
@@ -7,6 +11,28 @@ interface TaskListProps {
 
 export async function TaskList({ projectId }: TaskListProps = {}) {
   const tasks = await getTasks(projectId)
+
+  if (tasks.length === 0) {
+    return (
+      <Card>
+        <CardContent className="pt-12 pb-12">
+          <div className="text-center">
+            <ClipboardList className="h-16 w-16 mx-auto mb-4 text-muted-foreground/50" />
+            <h3 className="text-lg font-semibold mb-2">No tasks yet</h3>
+            <p className="text-muted-foreground mb-6">
+              Get started by creating your first task
+            </p>
+            <Button asChild>
+              <Link href="/dashboard/tasks/new">
+                <Plus className="h-4 w-4 mr-2" />
+                Add Task
+              </Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
 
   return (
     <div className="space-y-4">

--- a/lib/actions/tasks.ts
+++ b/lib/actions/tasks.ts
@@ -24,6 +24,7 @@ export async function createTask(_: unknown, formData: FormData) {
       dueDate: dueDate ? new Date(dueDate) : undefined,
     },
   })
+  revalidatePath('/dashboard/tasks')
   revalidatePath(`/dashboard/projects/${projectId}`)
   return { success: true }
 }


### PR DESCRIPTION
## Summary
- align tasks page layout with dashboard and projects, adding search/filter UI and icon button
- show empty state with call to action when no tasks exist
- revalidate tasks page after creating a task and use styled TaskCreate form

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6ea86ab6083279fd993dd2d8bf633