### PR TITLE
feat(db): add Clerk webhook and rebuild Neon Prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=REPLACE_WITH_YOUR_CLERK_PUBLISHABLE_KEY
 CLERK_SECRET_KEY=REPLACE_WITH_YOUR_CLERK_SECRET_KEY
+CLERK_WEBHOOK_SECRET=REPLACE_WITH_YOUR_CLERK_WEBHOOK_SECRET
 
 DATABASE_URL=postgresql://neondb_owner:REPLACE_WITH_YOUR_NEON_PASSWORD@ep-lucky-term-afdzts1t-pooler.c-2.us-west-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require
 DIRECT_URL=postgresql://neondb_owner:REPLACE_WITH_YOUR_NEON_PASSWORD@ep-lucky-term-afdzts1t.c-2.us-west-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ DIRECT_URL="postgresql://user:pass@host.neon.tech:5432/db?sslmode=require"
 SHADOW_DATABASE_URL="postgresql://user:pass@host.neon.tech:5432/db_shadow?sslmode=require"
 ```
 
+- Clerk Webhook
+```
+CLERK_WEBHOOK_SECRET="your_svix_signing_secret"
+```
+
 ---
 
 ## 🗺️ Roadmap (high level)

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -9,20 +9,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
-    // Get or create user in database
-    let dbUser = await prisma.user.findUnique({
+    const dbUser = await prisma.user.findUnique({
       where: { clerkId: user.id },
     })
 
     if (!dbUser) {
-      dbUser = await prisma.user.create({
-        data: {
-          clerkId: user.id,
-          email: user.emailAddresses[0]?.emailAddress || "",
-          firstName: user.firstName,
-          lastName: user.lastName,
-        },
-      })
+      return NextResponse.json({ error: "User not found" }, { status: 404 })
     }
 
     const body = await request.json()

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -9,20 +9,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
-    // Get or create user in database
-    let dbUser = await prisma.user.findUnique({
+    const dbUser = await prisma.user.findUnique({
       where: { clerkId: user.id },
     })
 
     if (!dbUser) {
-      dbUser = await prisma.user.create({
-        data: {
-          clerkId: user.id,
-          email: user.emailAddresses[0]?.emailAddress || "",
-          firstName: user.firstName,
-          lastName: user.lastName,
-        },
-      })
+      return NextResponse.json({ error: "User not found" }, { status: 404 })
     }
 
     const body = await request.json()

--- a/app/api/webhooks/clerk/route.ts
+++ b/app/api/webhooks/clerk/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server"
+import { Webhook } from "svix"
+import type { WebhookEvent } from "@clerk/nextjs/server"
+
+import { prisma } from "@/lib/db"
+
+const WEBHOOK_SECRET = process.env.CLERK_WEBHOOK_SECRET
+
+export async function POST(req: NextRequest) {
+  if (!WEBHOOK_SECRET) {
+    return NextResponse.json(
+      { error: "Missing Clerk webhook secret" },
+      { status: 500 },
+    )
+  }
+
+  const payload = await req.text()
+  const headers = {
+    "svix-id": req.headers.get("svix-id") ?? "",
+    "svix-timestamp": req.headers.get("svix-timestamp") ?? "",
+    "svix-signature": req.headers.get("svix-signature") ?? "",
+  }
+
+  let evt: WebhookEvent
+
+  try {
+    const wh = new Webhook(WEBHOOK_SECRET)
+    evt = wh.verify(payload, headers) as WebhookEvent
+  } catch (err) {
+    console.error("Webhook verification failed", err)
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 })
+  }
+
+  try {
+    switch (evt.type) {
+      case "user.created":
+      case "user.updated": {
+        const { id, email_addresses, first_name, last_name } = evt.data
+        await prisma.user.upsert({
+          where: { clerkId: id },
+          create: {
+            clerkId: id,
+            email: email_addresses[0]?.email_address || "",
+            firstName: first_name || null,
+            lastName: last_name || null,
+          },
+          update: {
+            email: email_addresses[0]?.email_address || "",
+            firstName: first_name || null,
+            lastName: last_name || null,
+          },
+        })
+        break
+      }
+      case "user.deleted": {
+        const { id } = evt.data
+        await prisma.user.delete({ where: { clerkId: id } })
+        break
+      }
+      case "subscription.created":
+      case "subscription.updated": {
+        const sub: any = evt.data
+        const user = await prisma.user.upsert({
+          where: { clerkId: sub.user_id },
+          update: {},
+          create: {
+            clerkId: sub.user_id,
+            email: "",
+          },
+        })
+
+        await prisma.subscription.upsert({
+          where: { id: sub.id },
+          create: {
+            id: sub.id,
+            userId: user.id,
+            status: sub.status,
+            planId: sub.plan_id ?? null,
+            trialEndsAt: sub.trial_ends_at ? new Date(sub.trial_ends_at) : null,
+          },
+          update: {
+            status: sub.status,
+            planId: sub.plan_id ?? null,
+            trialEndsAt: sub.trial_ends_at ? new Date(sub.trial_ends_at) : null,
+          },
+        })
+        break
+      }
+      case "subscription.deleted": {
+        const sub: any = evt.data
+        await prisma.subscription.delete({ where: { id: sub.id } })
+        break
+      }
+      default:
+        break
+    }
+  } catch (error) {
+    console.error("Error handling Clerk webhook", error)
+    return NextResponse.json({ error: "Webhook handler error" }, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true })
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,6 +6,7 @@ This document explains how to set up the project, run it locally, and contribute
 - Node.js 18 or later
 - PostgreSQL database (Neon recommended)
 - Copy `.env.example` to `.env` and configure `DATABASE_URL`, `DIRECT_URL`, and `SHADOW_DATABASE_URL`.
+- Add `CLERK_WEBHOOK_SECRET` for verifying Clerk webhooks.
 
 Install dependencies:
 ```bash

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,21 +1,16 @@
-import { PrismaClient } from '@prisma/client'
-import { Pool } from '@neondatabase/serverless'
-import { PrismaNeon } from '@prisma/adapter-neon'
+import { PrismaClient } from "@prisma/client"
+import { Pool } from "@neondatabase/serverless"
+import { PrismaNeon } from "@prisma/adapter-neon"
 
-const getDatabaseUrl = (): string => {
-  const url = process.env.DATABASE_URL
-  if (typeof url !== 'string' || url.length === 0) {
-    throw new Error('DATABASE_URL environment variable must be a non-empty string')
-  }
-  return url
+const connectionString = process.env.DATABASE_URL
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL environment variable must be set")
 }
 
-const poolConfig = { connectionString: getDatabaseUrl() };
-const adapter = new PrismaNeon(poolConfig);
+const pool = new Pool({ connectionString })
+const adapter = new PrismaNeon(pool)
 
-if (!adapter) {
-  throw new Error('PrismaNeon adapter is null')
-}
 declare global {
   var prisma: PrismaClient | undefined
 }
@@ -25,9 +20,9 @@ export const prisma =
   new PrismaClient({
     adapter,
     log:
-      process.env.NODE_ENV === 'development'
-        ? ['query', 'error', 'warn']
-        : ['error'],
+      process.env.NODE_ENV === "development"
+        ? ["query", "error", "warn"]
+        : ["error"],
   })
 
-if (process.env.NODE_ENV !== 'production') global.prisma = prisma
+if (process.env.NODE_ENV !== "production") global.prisma = prisma

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "react-resizable-panels": "3.0.4",
         "recharts": "3.1.2",
         "sonner": "2.0.7",
+        "svix": "^1.74.1",
         "tailwind-merge": "3.3.1",
         "tailwindcss-animate": "1.0.7",
         "vaul": "1.1.2",
@@ -5724,6 +5725,12 @@
         "benchmarks"
       ]
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
@@ -8288,6 +8295,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8588,6 +8601,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/reselect": {
       "version": "5.1.1",
@@ -9245,6 +9264,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svix": {
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.74.1.tgz",
+      "integrity": "sha512-99J8jSsk0viwkoAENVy/zpVoZxwn3kBdUvvpFaWiKjCkkTcqNZdoBqMmariDFceL4Q41ntWfUYxaWD37IAk9Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "@types/node": "^22.7.5",
+        "es6-promise": "^4.2.8",
+        "fast-sha256": "^1.3.0",
+        "url-parse": "^1.5.10",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/@types/node": {
+      "version": "22.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
+      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/svix/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/swr": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
@@ -9671,6 +9719,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -9721,6 +9779,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vaul": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-resizable-panels": "3.0.4",
     "recharts": "3.1.2",
     "sonner": "2.0.7",
+    "svix": "^1.74.1",
     "tailwind-merge": "3.3.1",
     "tailwindcss-animate": "1.0.7",
     "vaul": "1.1.2",

--- a/prisma/migrations/20250821000000_add_subscription/migration.sql
+++ b/prisma/migrations/20250821000000_add_subscription/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "public"."subscriptions" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "planId" TEXT,
+    "trialEndsAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "subscriptions_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "subscriptions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "subscriptions_userId_idx" ON "public"."subscriptions"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   assignedTasks       Task[]
   uploadedDocs        Document[]
   dailyLogs           DailyLog[]
+  subscriptions       Subscription[]
 
   @@map("users")
 }
@@ -219,6 +220,21 @@ model Entity {
   purchaseOrders PurchaseOrder[]
 
   @@map("entities")
+}
+
+model Subscription {
+  id          String   @id
+  userId      String
+  status      String
+  planId      String?
+  trialEndsAt DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("subscriptions")
 }
 
 // Enums


### PR DESCRIPTION
## Summary
- refactor Prisma client to use Neon serverless pool
- sync Clerk users and subscriptions through new webhook endpoint
- track subscription data with new Prisma model and migration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6eb9f5610832796ae993505e5b60b