### PR TITLE
fix: align documents schema with ui and neon

### DIFF
--- a/docs/documents.md
+++ b/docs/documents.md
@@ -7,6 +7,16 @@ The documents feature lets you upload, view, edit, and filter project files.
 - Fill out the form and select a file. Supported types include PDF, DOC, and common image formats.
 - Uploaded files are stored in `/public/uploads` and can be downloaded directly.
 
+### Document Types
+Available categories help organize files:
+- Contract
+- Permit
+- Plan
+- Photo
+- Invoice
+- Report
+- Other
+
 ## Manage
 - Use the filters to search by title, type, or project.
 - View details or download files from each document card.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,15 +1,29 @@
 import { PrismaClient } from "@prisma/client"
+import { Pool } from "@neondatabase/serverless"
+import { PrismaNeon } from "@prisma/adapter-neon"
 
 declare global {
-  // eslint-disable-next-line no-unused-vars
   var prisma: PrismaClient | undefined
 }
 
-export const prisma =
-  global.prisma ||
-  new PrismaClient({
+const createClient = () => {
+  const connectionString = process.env.DATABASE_URL
+  if (!connectionString) {
+    return new PrismaClient({
+      log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
+    })
+  }
+
+  const pool = new Pool({ connectionString })
+  const adapter = new PrismaNeon(pool)
+
+  return new PrismaClient({
+    adapter,
     log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
   })
+}
+
+export const prisma = global.prisma || createClient()
 
 if (process.env.NODE_ENV !== "production") {
   global.prisma = prisma

--- a/prisma/migrations/20250822000000_update_document_model/migration.sql
+++ b/prisma/migrations/20250822000000_update_document_model/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+ALTER TYPE "public"."DocumentType" ADD VALUE IF NOT EXISTS 'REPORT';
+
+-- Rename column
+ALTER TABLE "public"."documents" RENAME COLUMN "url" TO "filePath";
+
+-- Add columns
+ALTER TABLE "public"."documents" ADD COLUMN "description" TEXT;
+ALTER TABLE "public"."documents" ADD COLUMN "fileName" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "public"."documents" ALTER COLUMN "fileName" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,8 +146,10 @@ model Document {
   id           String       @id @default(cuid())
   projectId    String?
   title        String
+  description  String?
   type         DocumentType
-  url          String
+  fileName     String
+  filePath     String
   fileSize     Int?
   mimeType     String?
   uploadedById String
@@ -273,6 +275,7 @@ enum DocumentType {
   RECEIPT
   PLAN
   PHOTO
+  REPORT
   OTHER
 }
 


### PR DESCRIPTION
## Summary
- add Neon adapter and connection handling for Prisma
- expand documents schema and type to match UI expectations
- document available document categories

## Testing
- `npx prisma generate`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7186b0980832786b47c4bb2ecf377